### PR TITLE
Bulk insert fix for #180 that passes tests

### DIFF
--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -38,6 +38,7 @@ from .utils import CollectionDebugWrapper
 class DatabaseFeatures(NonrelDatabaseFeatures):
     supports_microsecond_precision = False
     supports_long_model_names = False
+    distinguishes_insert_from_update = True
 
 
 class DatabaseOperations(NonrelDatabaseOperations):

--- a/django_mongodb_engine/base.py
+++ b/django_mongodb_engine/base.py
@@ -38,7 +38,6 @@ from .utils import CollectionDebugWrapper
 class DatabaseFeatures(NonrelDatabaseFeatures):
     supports_microsecond_precision = False
     supports_long_model_names = False
-    distinguishes_insert_from_update = True
 
 
 class DatabaseOperations(NonrelDatabaseOperations):

--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -390,7 +390,7 @@ class SQLInsertCompiler(NonrelInsertCompiler, SQLCompiler):
         if return_id:
             return collection.save(doc, **options)
         else:
-            collection.save(doc, **options)
+            collection.insert(docs, **options)
 
 
 # TODO: Define a common nonrel API for updates and add it to the nonrel

--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -387,10 +387,13 @@ class SQLInsertCompiler(NonrelInsertCompiler, SQLCompiler):
         collection = self.get_collection()
         options = self.connection.operation_flags.get('save', {})
 
-        if return_id:
-            return collection.save(doc, **options)
-        else:
+	if len(docs) > 1:
             collection.insert(docs, **options)
+        else:
+            if return_id:
+                return collection.save(doc, **options)
+            else:
+                collection.save(doc, **options)
 
 
 # TODO: Define a common nonrel API for updates and add it to the nonrel
@@ -440,6 +443,10 @@ class SQLUpdateCompiler(NonrelUpdateCompiler, SQLCompiler):
         info = collection.update(criteria, update_spec, multi=multi, **options)
         if info is not None:
             return info.get('n')
+        update_flags = self.connection.operation_flags['update']
+        if 'safe' in update_flags and update_flags['safe']:
+            return None
+        return 1
 
 
 class SQLDeleteCompiler(NonrelDeleteCompiler, SQLCompiler):

--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -387,7 +387,7 @@ class SQLInsertCompiler(NonrelInsertCompiler, SQLCompiler):
         collection = self.get_collection()
         options = self.connection.operation_flags.get('save', {})
 
-	if len(docs) > 1:
+        if len(docs) > 1:
             collection.insert(docs, **options)
         else:
             if return_id:

--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -443,7 +443,7 @@ class SQLUpdateCompiler(NonrelUpdateCompiler, SQLCompiler):
         info = collection.update(criteria, update_spec, multi=multi, **options)
         if info is not None:
             return info.get('n')
-        return 1
+        return 0
 
 
 class SQLDeleteCompiler(NonrelDeleteCompiler, SQLCompiler):

--- a/django_mongodb_engine/compiler.py
+++ b/django_mongodb_engine/compiler.py
@@ -443,9 +443,6 @@ class SQLUpdateCompiler(NonrelUpdateCompiler, SQLCompiler):
         info = collection.update(criteria, update_spec, multi=multi, **options)
         if info is not None:
             return info.get('n')
-        update_flags = self.connection.operation_flags['update']
-        if 'safe' in update_flags and update_flags['safe']:
-            return None
         return 1
 
 

--- a/tests/query/tests.py
+++ b/tests/query/tests.py
@@ -354,6 +354,11 @@ class BasicQueryTests(TestCase):
             [{'title': u'footitle', 'content': u'foocontent'},
              {'title': u'footitle2', 'content': u'foocontent2'}])
 
+    def test_bulk_create(self):
+        blogs = [Blog(title='blog-%d' % i) for i in range(3)]
+        Blog.objects.bulk_create(blogs)
+        self.assertEqual(Blog.objects.count(), 3)
+
 
 class UpdateTests(TestCase):
 


### PR DESCRIPTION
@JuanjoArreola: I added a few things to your fix, namely a test for bulk commit and a fix for an exception in the code.

Regarding the exception, it seems you wanted to return `None` in case the option `{update: safe: true}}` is passed to the update operation, and otherwise return 1...

But I cannot see any reason for this, since the update method should return the number of records that have been updated (at least that's expected from [django's docs](https://docs.djangoproject.com/en/1.4/topics/db/queries/#updating-multiple-objects-at-once)), and safe is a valid update operator as seen in [pymongo docs](http://api.mongodb.org/python/current/api/pymongo/collection.html#pymongo.collection.Collection.update).

Additionally, the code was unsafe, crashing the tests with `KeyError` (since the operation flags are optional).